### PR TITLE
add db migrations, readmes to explain

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,25 @@
+# Setting up the ohmage database
+*This process is changing, starting with the 2.17 release!*
+
+## Migrations
+Starting with ohmage 2.17, the ohmage db setup is getting a (majorly needed) overhaul.  Most importantly, you should notice the new directory, `/migration` which contain the needed db migration scripts. These migrations are supported via [Flyway](http://flywaydb.org/).  Take a look at the README in that directory for information on execution, but some very brief info is below:
+### Updating from 2.16 to 2.17
+Since the flyway migrations begin to exist with 2.17, we'll first need to baseline the existing db.  With the flyway executable in your path, and it's config given the proper db info (take a look at the README in the `migration` directory for more help on this) execute:
+```bash
+flyway baseline -baselineVersion=3
+```
+This will **not** touch your existing 2.16 database, save for creating a new table which will manage the migrations and marking all migrations up to V3 as "successful".  From here on, migrations can be done by simply executing `flyway migrate`. This is safe to execute as many times as you'd like, it will only perform new migrations.
+### "From scratch"
+With the flyway dependencies resolved/set up, you can simply execute `flyway migrate` to get started.  It should be noted that one of the migrations (V3) is actually seed data (pertaining to filesystem specifics, terms of service, etc.) that you may want to modify before executing depending on your environment.  The defaults, however, are quite sane and can always be changed in the `preference` table at a later time.  Again, please take a look at the README file in the migrations directory if you have more questions about the process. 
+
+## Manual SQL scripts
+*Please note that the 2.17 version of the server code will be the last version to offer this SQL script option*. Additionally, these scripts can only be run once, and do not guarantee success/failure outputs.
+### Updating from 2.16 to 2.17
+Please execute the script found at `sql/update/2.16-2.17.sql` to prepare your database for the ohmage 2.17 upgrade.
+### "From scratch"
+In order to get a working ohmage 2.17 database from scratch, you'll need to pipe a number of files into the ohmage db:
+```bash
+sql/base/ohmage-ddl.sql
+sql/preferences/default_preferences.sql
+sql/settings/*.sql
+```

--- a/db/migration/README.md
+++ b/db/migration/README.md
@@ -1,0 +1,30 @@
+# First Class Migrations!
+Happy Day! Migrations have finally arrived for ohmage.  Thanks to the awesome [flyway](https://flywaydb.org), this directory has the hook up to easy db prepping and upgrades!
+
+## Execution
+After following the download/config procedures below, you can simply run `flyway migrate` to run new migrations. Please read the note on baselining below if you have an existing ohmage database that you'd like to get moving with flyway.
+
+## Flyway download
+Assuming you're in your home directory, follow the commands below to download/extract flyway:
+```bash
+wget http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/3.2.1/flyway-commandline-3.2.1.tar.gz
+tar xvf flyway-commandline-3.2.1.tar.gz
+```
+
+You'll now have a directory at `~/flyway-3.2.1/`. If you want the flyway executable in your path, go for it: `export PATH=~/flyway-3.2.1/:$PATH` or just `cd` into the directory and execute `./flyway` as needed.
+
+## Config
+Assuming you've followed the above, the default flyway config file lives at `~/flyway-3.2.1/conf/flyway.conf`. When you execute flyway you can pass `-configFile=/path/to/your/alt/location` to specify a different location. The configuration is quite simple, an example below (remember to replace the $VARIABLES with your own db connection info!).
+
+```
+flyway.url=jdbc:mysql://$DB_HOST:$DB_PORT/$DB_NAME
+flyway.user=$DB_USER
+flyway.password=$DB_PASSWORD
+flyway.placeholders.fqdn=$FQDN
+flyway.placeholders.base_dir=/var/lib/ohmage
+flyway.locations=filesystem:/path/to/this/migration/directory
+```
+`fqdn` and `base_dir` placeholders are ohmage specific and should be set to the fully qualified domain name of the ohmage server as well as the base directory for filesystem storage of ohmage survey response media. Additionally, you don't need to set the "locations" parameter if drop the migrations in this directory to `~/flyway-3.2.1/sql`.
+
+## A note on "baselining"
+If you're starting with an existing ohmage 2.16 database, please execute `flyway baseline -baselineVersion=3` to set flyway migrations to the baseline of ohmage 2.16. 

--- a/db/migration/V1__Create_ohmage_base.sql
+++ b/db/migration/V1__Create_ohmage_base.sql
@@ -1,0 +1,591 @@
+CREATE TABLE audit_request_type (
+  id int unsigned NOT NULL auto_increment,
+  request_type varchar(8) NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE audit (
+  id int unsigned NOT NULL auto_increment,
+  request_type_id int unsigned NOT NULL,
+  uri text NOT NULL,
+  client text,
+  request_id VARCHAR(255) NOT NULL,
+  device_id text,
+  response text NOT NULL,
+  received_millis long NOT NULL,
+  respond_millis long NOT NULL,
+  db_timestamp timestamp default current_timestamp NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (request_type_id) REFERENCES audit_request_type (id) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE audit_extra (
+  id int unsigned NOT NULL auto_increment,
+  audit_id int unsigned NOT NULL,
+  extra_key text NOT NULL,
+  extra_value text NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (audit_id) REFERENCES audit (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE audit_parameter (
+  id int unsigned NOT NULL auto_increment,
+  audit_id int unsigned NOT NULL,
+  param_key text NOT NULL,
+  param_value text NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (audit_id) REFERENCES audit (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE class (
+  id int unsigned NOT NULL auto_increment,
+  urn varchar(255) NOT NULL,
+  name varchar(255) NOT NULL,
+  description text,
+  PRIMARY KEY (id),
+  UNIQUE (urn)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE campaign_running_state (
+  id int unsigned NOT NULL auto_increment,
+  running_state varchar(50) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (running_state)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE campaign_privacy_state (
+  id int unsigned NOT NULL auto_increment,
+  privacy_state varchar(50) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (privacy_state)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE campaign (
+  id int unsigned NOT NULL auto_increment,
+  urn varchar(255) NOT NULL,
+  name varchar(255) NOT NULL,
+  description text,
+  xml mediumtext NOT NULL,
+  running_state_id int unsigned NOT NULL,
+  privacy_state_id int unsigned NOT NULL,
+  creation_timestamp datetime NOT NULL,
+  icon_url varchar(255),
+  authored_by varchar(255),
+  PRIMARY KEY (id),
+  UNIQUE (urn),
+  CONSTRAINT FOREIGN KEY (running_state_id) REFERENCES campaign_running_state (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (privacy_state_id) REFERENCES campaign_privacy_state (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE campaign_class (
+  id int unsigned NOT NULL auto_increment,
+  campaign_id int unsigned NOT NULL,
+  class_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (campaign_id, class_id),
+  CONSTRAINT FOREIGN KEY (campaign_id) REFERENCES campaign (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (class_id) REFERENCES class (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE user (
+  id int unsigned NOT NULL auto_increment,
+  username varchar(25) NOT NULL,
+  password varchar(60) NOT NULL,
+  enabled bit NOT NULL,
+  new_account bit NOT NULL,
+  campaign_creation_privilege bit NOT NULL,
+  class_creation_privilege bit NOT NULL DEFAULT FALSE,
+  user_setup_privilege bit NOT NULL DEFAULT FALSE,
+  email_address varchar(320),
+  admin bit NOT NULL,
+  last_modified_timestamp timestamp DEFAULT now() ON UPDATE now(),
+  PRIMARY KEY (id),
+  UNIQUE (username)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE user_personal (
+  id int unsigned NOT NULL auto_increment,
+  user_id int unsigned NOT NULL,
+  first_name varchar(255) NOT NULL,
+  last_name varchar(255) NOT NULL,
+  organization varchar(255) NOT NULL,
+  personal_id varchar(255) NOT NULL,
+  last_modified_timestamp timestamp DEFAULT now() ON UPDATE now(),
+  PRIMARY KEY (id),
+  UNIQUE (user_id),
+  UNIQUE (first_name, last_name, organization, personal_id), 
+  CONSTRAINT FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE user_registration(
+    id int unsigned NOT NULL auto_increment,
+    user_id int unsigned NOT NULL,
+    registration_id VARCHAR(128) NOT NULL,
+    request_timestamp BIGINT UNSIGNED NOT NULL,
+    accepted_timestamp BIGINT UNSIGNED DEFAULT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (user_id),
+    CONSTRAINT user_id FOREIGN KEY (user_id) REFERENCES user (id) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE user_role (
+  id tinyint unsigned NOT NULL auto_increment,
+  role varchar(50) NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE user_role_campaign (
+  id int unsigned NOT NULL auto_increment,
+  user_id int unsigned NOT NULL,
+  campaign_id int unsigned NOT NULL,
+  user_role_id tinyint unsigned NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (user_id, campaign_id, user_role_id),
+  CONSTRAINT FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (campaign_id) REFERENCES campaign (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (user_role_id) REFERENCES user_role (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE user_class_role (
+  id int unsigned NOT NULL auto_increment,
+  role varchar(50) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (role)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE user_class (
+  id int unsigned NOT NULL auto_increment,
+  user_id int unsigned NOT NULL,
+  class_id int unsigned NOT NULL,
+  user_class_role_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (user_id, class_id),
+  CONSTRAINT FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (class_id) REFERENCES class (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (user_class_role_id) REFERENCES user_class_role (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE campaign_class_default_role (
+  id int unsigned NOT NULL auto_increment,
+  campaign_class_id int unsigned NOT NULL,
+  user_class_role_id int unsigned NOT NULL,
+  user_role_id tinyint unsigned NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (campaign_class_id, user_class_role_id, user_role_id),
+  CONSTRAINT FOREIGN KEY (campaign_class_id) REFERENCES campaign_class (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (user_class_role_id) REFERENCES user_class_role (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (user_role_id) REFERENCES user_role (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE survey_response_privacy_state (
+  id int unsigned NOT NULL auto_increment,
+  privacy_state varchar(50) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (privacy_state)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE survey_response (
+  id int unsigned NOT NULL auto_increment,
+  uuid CHAR(36) NOT NULL UNIQUE,
+  user_id int unsigned NOT NULL,
+  campaign_id int unsigned NOT NULL,
+  client tinytext NOT NULL,
+  epoch_millis bigint unsigned NOT NULL, 
+  phone_timezone varchar(32) NOT NULL,
+  survey_id varchar(250) NOT NULL,    
+  survey text CHARACTER SET utf8 NOT NULL,
+  launch_context text,             
+  location_status tinytext NOT NULL,
+  location text,                   
+  upload_timestamp datetime NOT NULL,
+  last_modified_timestamp timestamp default current_timestamp on update current_timestamp,
+  privacy_state_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  KEY key_user_id (user_id),
+  KEY key_campaign_id (campaign_id),
+  CONSTRAINT FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE,    
+  CONSTRAINT FOREIGN KEY (campaign_id) REFERENCES campaign (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (privacy_state_id) REFERENCES survey_response_privacy_state (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE prompt_response (
+  id int unsigned NOT NULL auto_increment,
+  survey_response_id int unsigned NOT NULL,
+  prompt_id varchar(250) NOT NULL,
+  prompt_type varchar(250) NOT NULL,
+  repeatable_set_id varchar(250),
+  repeatable_set_iteration tinyint unsigned,
+  response text CHARACTER SET utf8 NOT NULL,
+  audit_timestamp timestamp default current_timestamp on update current_timestamp,
+  PRIMARY KEY (id),
+  INDEX (survey_response_id),
+  INDEX (prompt_id),
+  INDEX response_image (response(36)),
+  
+  CONSTRAINT FOREIGN KEY (survey_response_id) REFERENCES survey_response (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE url_based_resource (
+    id int unsigned NOT NULL auto_increment,
+    user_id int unsigned NOT NULL,
+    client tinytext NOT NULL,
+    uuid char (36) NOT NULL,
+    url text,
+    audit_timestamp timestamp default current_timestamp on update current_timestamp,
+    processed BOOLEAN NOT NULL DEFAULT FALSE,
+    UNIQUE (uuid),
+    PRIMARY KEY (id),
+    CONSTRAINT FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE mobility_privacy_state (
+  id int unsigned NOT NULL auto_increment,
+  privacy_state varchar(50) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (privacy_state)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE mobility (
+  id int unsigned NOT NULL auto_increment,
+  uuid CHAR(36) NOT NULL UNIQUE,
+  user_id int unsigned NOT NULL,
+  client tinytext NOT NULL,
+  epoch_millis bigint unsigned NOT NULL,
+  phone_timezone varchar(32) NOT NULL,
+  location_status tinytext NOT NULL,
+  location text,
+  mode varchar(30) NOT NULL,
+  upload_timestamp datetime NOT NULL,
+  audit_timestamp timestamp default current_timestamp on update current_timestamp,
+  privacy_state_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  INDEX (uuid),
+  INDEX index_time (epoch_millis),
+  CONSTRAINT FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (privacy_state_id) REFERENCES mobility_privacy_state (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE mobility_extended (
+  id int unsigned NOT NULL auto_increment,
+  mobility_id int unsigned NOT NULL,
+  sensor_data text NOT NULL,
+  features text NOT NULL,
+  classifier_version tinytext NOT NULL,
+  audit_timestamp timestamp default current_timestamp on update current_timestamp,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (mobility_id) REFERENCES mobility (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE preference (
+  p_key varchar(50) NOT NULL,
+  p_value text NOT NULL,
+  UNIQUE unique_p_key (p_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE document_privacy_state (
+  id int unsigned NOT NULL auto_increment,
+  privacy_state varchar(50) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (privacy_state)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE document_role (
+  id int unsigned NOT NULL auto_increment,
+  role varchar(50) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (role)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE document (
+  id int unsigned NOT NULL auto_increment,
+  uuid char(36) NOT NULL,
+  name varchar(255) NOT NULL,
+  description text,
+  extension varchar(50),
+  url text NOT NULL,
+  size int unsigned NOT NULL,
+  privacy_state_id int unsigned NOT NULL,
+  last_modified_timestamp timestamp default current_timestamp on update current_timestamp,
+  creation_timestamp datetime NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (uuid),
+  CONSTRAINT FOREIGN KEY (privacy_state_id) REFERENCES document_privacy_state (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE document_class_role (
+  id int unsigned NOT NULL auto_increment,
+  document_id int unsigned NOT NULL,
+  class_id int unsigned NOT NULL,
+  document_role_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (document_id, class_id),
+  CONSTRAINT FOREIGN KEY (document_id) REFERENCES document (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (class_id) REFERENCES class (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE document_campaign_role (
+  id int unsigned NOT NULL auto_increment,
+  document_id int unsigned NOT NULL,
+  campaign_id int unsigned NOT NULL,
+  document_role_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (document_id, campaign_id),
+  CONSTRAINT FOREIGN KEY (document_id) REFERENCES document (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (campaign_id) REFERENCES campaign (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE document_user_role (
+  id int unsigned NOT NULL auto_increment,
+  document_id int unsigned NOT NULL,
+  user_id int unsigned NOT NULL,
+  document_role_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (document_id, user_id),
+  CONSTRAINT FOREIGN KEY (document_id) REFERENCES document (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE document_user_creator (
+  id int unsigned NOT NULL auto_increment,
+  document_id int unsigned NOT NULL,
+  username varchar(25) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (document_id),
+  CONSTRAINT FOREIGN KEY (document_id) REFERENCES document (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE annotation (
+  id int unsigned NOT NULL auto_increment,
+  uuid CHAR(36) NOT NULL UNIQUE,
+  user_id int unsigned NOT NULL,
+  epoch_millis bigint unsigned NOT NULL,
+  timezone varchar(32) NOT NULL,
+  client tinytext NOT NULL, 
+  annotation text NOT NULL,
+  last_modified_timestamp timestamp default current_timestamp on update current_timestamp,
+  creation_timestamp datetime NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE survey_response_annotation (
+  id int unsigned NOT NULL auto_increment,
+  survey_response_id int unsigned NOT NULL,
+  annotation_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (survey_response_id) REFERENCES survey_response (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (annotation_id) REFERENCES annotation (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE prompt_response_annotation (
+  id int unsigned NOT NULL auto_increment,
+  prompt_response_id int unsigned NOT NULL,
+  annotation_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (prompt_response_id) REFERENCES prompt_response (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (annotation_id) REFERENCES annotation (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE campaign_annotation (
+  id int unsigned NOT NULL auto_increment,
+  campaign_id int unsigned NOT NULL,
+  annotation_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (campaign_id) REFERENCES campaign (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (annotation_id) REFERENCES annotation (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE annotation_annotation (
+  id int unsigned NOT NULL auto_increment,
+  root_annotation_id int unsigned NOT NULL,
+  annotation_id int unsigned NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT FOREIGN KEY (root_annotation_id) REFERENCES annotation (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FOREIGN KEY (annotation_id) REFERENCES annotation (id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE observer (
+    id int unsigned NOT NULL AUTO_INCREMENT,
+    user_id int unsigned NOT NULL,
+    observer_id varchar(255) NOT NULL,
+    version bigint NOT NULL,
+    name varchar(256) NOT NULL,
+    description text NOT NULL,
+    version_string varchar(32) NOT NULL,
+    last_modified_timestamp timestamp DEFAULT now() ON UPDATE now(),
+    PRIMARY KEY (id),
+    UNIQUE KEY observer_unique_key_id_version (observer_id, version),
+    KEY observer_key_observer_id (observer_id),
+    KEY observer_key_user_id (user_id),
+    CONSTRAINT observer_foreign_key_user_id 
+       FOREIGN KEY (user_id) 
+       REFERENCES user (id) 
+       ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE observer_stream (
+    id int unsigned NOT NULL AUTO_INCREMENT,
+    stream_id varchar(255) NOT NULL,
+    version bigint NOT NULL,
+    name varchar(256) NOT NULL,
+    description text NOT NULL,
+    with_id boolean DEFAULT NULL,
+    with_timestamp boolean DEFAULT NULL,
+    with_location boolean DEFAULT NULL,
+    stream_schema text NOT NULL,
+    last_modified_timestamp timestamp DEFAULT now() ON UPDATE now(),
+    PRIMARY KEY (id),
+    KEY observer_stream_key_stream_id (stream_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE observer_stream_link (
+  id int(10) unsigned NOT NULL AUTO_INCREMENT,
+  observer_id int(10) unsigned NOT NULL,
+  observer_stream_id int(10) unsigned NOT NULL,
+  PRIMARY KEY (id),
+  KEY observer_stream_link_key_observer_id (observer_id),
+  KEY observer_stream_link_key_stream_id (observer_stream_id),
+  UNIQUE KEY observer_stream_link_unique_key_observer_stream 
+    (observer_id, observer_stream_id),
+  CONSTRAINT observer_stream_link_foreign_key_observer_id
+    FOREIGN KEY (observer_id)
+    REFERENCES observer (id)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT observer_stream_link_foreign_key_stream_id
+    FOREIGN KEY (observer_id)
+    REFERENCES observer (id)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE observer_stream_data (
+  id int unsigned NOT NULL AUTO_INCREMENT,
+  user_id int unsigned NOT NULL,
+  observer_stream_link_id int unsigned NOT NULL,
+  uid varchar(255) DEFAULT NULL,
+  time bigint(20) DEFAULT NULL,
+  time_offset bigint(20) DEFAULT NULL,
+  time_adjusted bigint(20) DEFAULT NULL,
+  time_zone varchar(32) DEFAULT NULL,
+  location_timestamp varchar(64) DEFAULT NULL,
+  location_latitude double DEFAULT NULL,
+  location_longitude double DEFAULT NULL,
+  location_accuracy double DEFAULT NULL,
+  location_provider varchar(255) DEFAULT NULL,
+  data longtext NOT NULL,
+  last_modified_timestamp timestamp DEFAULT now() ON UPDATE now(),
+  PRIMARY KEY (id),
+  KEY observer_stream_data_key_observer_stream_link_id (observer_stream_link_id),
+  KEY observer_stream_data_key_user_id (user_id),
+  INDEX observer_stream_data_index_time (time),
+  INDEX observer_stream_data_index_time_adjusted (time_adjusted),
+  INDEX `observer_stream_data_query`
+    (`user_id`,`observer_stream_link_id`,`time_adjusted`,`time`),
+  INDEX `observer_stream_data_index_link_user_adjusted`
+    (`observer_stream_link_id`,`user_id`,`time_adjusted`),
+  INDEX `osd_duplicate_data_point_read`
+    (`user_id`, `observer_stream_link_id`, `uid`),  
+  CONSTRAINT observer_stream_data_foreign_key_user_id 
+    FOREIGN KEY (user_id) 
+    REFERENCES user (id) 
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT observer_stream_data_foreign_key_observer_stream_link_id 
+    FOREIGN KEY (observer_stream_link_id) 
+    REFERENCES observer_stream_link (id) 
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `campaign_survey_lookup` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `survey_id` varchar(255) NOT NULL,
+  `campaign_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `campaign_survey_lookup_index_survey_id` (`survey_id`),
+  KEY `campaign_survey_lookup_fk_campaign_id` (`campaign_id`),
+  CONSTRAINT `campaign_survey_lookup_fk_campaign_id`
+    FOREIGN KEY (`campaign_id`)
+    REFERENCES `campaign` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `campaign_prompt_lookup` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `prompt_id` varchar(255) NOT NULL,
+  `campaign_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `campaign_prompt_lookup_index_prompt_id` (`prompt_id`),
+  KEY `campaign_prompt_lookup_fk_campaign_id` (`campaign_id`),
+  CONSTRAINT `campaign_prompt_lookup_fk_campaign_id`
+    FOREIGN KEY (`campaign_id`)
+    REFERENCES `campaign` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `campaign_mask` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `assigner_user_id` int(10) unsigned NOT NULL,
+  `assignee_user_id` int(10) unsigned NOT NULL,
+  `campaign_id` int(10) unsigned NOT NULL,
+  `mask_id` varchar(36) NOT NULL,
+  `creation_time` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `campaign_mask_index_mask_id` (`mask_id`),
+  CONSTRAINT `campaign_mask_fk_assigner_user_id` FOREIGN KEY (`assigner_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `campaign_mask_fk_assignee_user_id` FOREIGN KEY (`assignee_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `campaign_mask_fk_campaign_id` FOREIGN KEY (`campaign_id`) REFERENCES `campaign` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `campaign_mask_survey_id` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `campaign_mask_id` int(10) unsigned NOT NULL,
+  `survey_id` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `campaing_mask_unique_mask_survey` (`campaign_mask_id`,`survey_id`),
+  CONSTRAINT `campaign_mask_fk_survey_id` FOREIGN KEY (`campaign_mask_id`) REFERENCES `campaign_mask` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `omh_authentication` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `domain` varchar(100) NOT NULL,
+  `auth_key` varchar(100) NOT NULL,
+  `auth_value` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `omh_authentication_unique_domain_key` (`domain`,`auth_key`),
+  KEY `omh_authentication_index_domain` (`domain`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `campaign_mask_survey_prompt_map` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `campaign_mask_id` int(10) unsigned NOT NULL,
+    `survey_id` varchar(255) NOT NULL,
+    `prompt_id` varchar(255) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `campaing_mask_unique_mask_survey_prompt`
+        (`campaign_mask_id`,`survey_id`, `prompt_id`),
+    CONSTRAINT `campaign_mask_fk_survey_prompt_map`
+        FOREIGN KEY (`campaign_mask_id`) REFERENCES `campaign_mask` (`id`)
+        ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `observer_stream_data_invalid` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `user_id` int(10) unsigned NOT NULL,
+    `observer_id` int(10) unsigned NOT NULL,
+    `time_recorded` bigint(20) NOT NULL,
+    `point_index` int(20) unsigned NOT NULL,
+    `reason` text NOT NULL,
+    `data` longtext NOT NULL,
+    `last_modified_timestamp` timestamp NOT NULL
+        DEFAULT CURRENT_TIMESTAMP
+        ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    CONSTRAINT `observer_stream_data_invalid_fk_user_id`
+        FOREIGN KEY (`user_id`)
+        REFERENCES `user` (`id`)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE,
+    CONSTRAINT `observer_stream_data_invalid_fk_observer_id`
+      FOREIGN KEY (`observer_id`)
+      REFERENCES `observer` (`id`)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/db/migration/V2__Insert_ohmage_settings.sql
+++ b/db/migration/V2__Insert_ohmage_settings.sql
@@ -1,0 +1,313 @@
+-- Adds the request types for the audit table.
+INSERT INTO audit_request_type(request_type) VALUES 
+    ('get'), 
+    ('post'), 
+    ('options'), 
+    ('head'), 
+    ('put'), 
+    ('delete'), 
+    ('trace'), 
+    ('unknown');
+
+-- Inserts the default campaign privacy states into the lookup table in the database.
+INSERT INTO campaign_privacy_state(privacy_state) VALUES 
+    ('shared'), 
+    ('private');
+
+-- This SQL is intended to be run after andwellness-ddl.sql to initialize the user_roles in the system.
+INSERT INTO user_role (role) VALUES 
+    ('participant'), 
+    ('author'), 
+    ('analyst'), 
+    ('supervisor');
+
+-- Inserts the default campaign running states into the lookup table in the database.
+INSERT INTO campaign_running_state(running_state) VALUES
+    ('running'), 
+    ('stopped');
+
+-- Insert the default roles for a class.
+INSERT INTO user_class_role(role) VALUES 
+    ('privileged'), 
+    ('restricted');
+
+-- Inserts the default document privacy states into the lookup table in the database.
+INSERT INTO user(username, password, admin, new_account, enabled, campaign_creation_privilege) VALUES 
+    ('ohmage.admin', '$2a$13$yxus2tQ3/QiOwWcELImOQuy9d5PXWbByQ6Bhp52b1se7fNYGFxN5i', true, true, true, true);
+
+
+-- Creates the default, public class.
+INSERT INTO class(urn, name, description)
+    VALUES ('urn:class:public', 'Public Class', 'This is the public class for all self-registered users.');
+
+
+-- Inserts the default document privacy states into the lookup table in the database.
+INSERT INTO document_privacy_state(privacy_state) VALUES 
+    ('private'), 
+    ('shared');
+
+-- Insert the default roles for a document.
+INSERT INTO document_role(role) VALUES 
+    ('reader'), 
+    ('writer'), 
+    ('owner');
+
+-- Inserts the default Mobility privacy states into the lookup table in the database.
+INSERT INTO mobility_privacy_state(privacy_state) VALUES 
+    ('private');
+
+-- Inserts the default survey response privacy states into the lookup table in the database.
+INSERT INTO survey_response_privacy_state(privacy_state) VALUES 
+    ('shared'), 
+    ('private');
+
+-- Add the default observers.
+-- This must run after the default_admin script.
+-- Define the observer's IDs.
+SET
+    @ohmage.admin_id = (SELECT id FROM user WHERE username='ohmage.admin'),
+    @analytics_observer_id = 'org.ohmage.Analytics',
+    @logprobe_observer_id = 'org.ohmage.LogProbe',
+    @mobility_observer_id = 'edu.ucla.cens.Mobility';
+
+-- Insert the observer definitions.
+INSERT INTO 
+    observer(user_id, observer_id, version, name, description, version_string)
+    VALUES
+        (
+            @ohmage.admin_id,
+            @analytics_observer_id,
+            1,
+            'Ohmage Analytics',
+            'Logs analytics specific to ohmage.',
+            '1.0'
+        ),
+        (
+            @ohmage.admin_id,
+            @logprobe_observer_id,
+            1,
+            'LogProbe',
+            'Logs data and analytics.',
+            '1.0'
+        ),
+        (
+            @ohmage.admin_id,
+            @mobility_observer_id,
+            2012061300,
+            'Mobility',
+            'Collects movement information about a user, e.g. walk, run, etc.',
+            '3.0'
+        );
+        
+-- Get the database IDs for the observers.
+SET
+    @analytics_id =
+        (SELECT id FROM observer WHERE observer_id = @analytics_observer_id),
+    @logprobe_id =
+        (SELECT id FROM observer WHERE observer_id = @logprobe_observer_id),
+    @mobility_id = 
+        (SELECT id FROM observer WHERE observer_id = @mobility_observer_id);
+
+-- Define the stream IDs
+SET
+    @analytics_prompt_stream_id = 'prompt',
+    @analytics_trigger_stream_id = 'trigger',
+    @logprobe_activity_stream_id = 'activity',
+    @logprobe_log_stream_id = 'log',
+    @logprobe_network_stream_id = 'network',
+    @logprobe_service_stream_id = 'service',
+    @logprobe_widget_stream_id = 'widget',
+    @mobility_regular_stream_id = 'regular',
+    @mobility_error_stream_id = 'error',
+    @mobility_extended_stream_id = 'extended';
+
+-- Insert the stream definitions.
+INSERT INTO
+    observer_stream(
+        stream_id,
+        version,
+        name,
+        description,
+        with_id,
+        with_timestamp,
+        with_location,
+        stream_schema)
+    VALUES
+        (
+            @analytics_prompt_stream_id,
+            1,
+            'Prompt',
+            'Logs information about what prompts are shown.',
+            true,
+            true,
+            false,
+            '{"type":"object","doc":"Prompt interaction.","fields":[{"name":"id","doc":"The promptId.","type":"string"},{"name":"type","doc":"The prompt type.","type":"string"},{"name":"status","doc":"Status information about the activity. Either ON or OFF.","type":"string"}]}'
+        ),
+        (
+            @analytics_trigger_stream_id,
+            1,
+            'Trigger',
+            'Logs information about triggers in ohmage.',
+            true,
+            true,
+            false,
+            '{"type":"object","doc":"Trigger interaction.","fields":[{"name":"action","doc":"The action that was currently applied to the trigger. One of delete, add, trigger, update, or ignore.","type":"string"},{"name":"type","doc":"Trigger type.","type":"string"},{"name":"count","doc":"Current number of triggers for this campaign and trigger type set up in the system.","type":"number"},{"name":"campaign","doc":"The campaign urn to which this trigger belongs.","type":"string"}]}'
+        ),
+        (
+            @logprobe_activity_stream_id,
+            1,
+            'Activity',
+            'Analytics for activity interaction.',
+            true,
+            true,
+            false,
+            '{"type":"object","doc":"Activity interaction.","fields":[{"name":"activity","doc":"The class name of the activity.","type":"string"},{"name":"status","doc":"Status information about the activity. Either ON or OFF.","type":"string"}]}'
+        ),
+        (
+            @logprobe_log_stream_id,
+            1,
+            'Log',
+            'Log message.',
+            true,
+            true,
+            false,
+            '{"type":"object","doc":"log message.","fields":[{"name":"level","doc":"Log level. One of error, warning, info, debug, or verbose.","type":"string"},{"name":"tag","doc":"Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.","type":"string"},{"name":"message","doc":"The message you would like logged.","type":"string"}]}'
+        ),
+        (
+            @logprobe_network_stream_id,
+            1,
+            'Network',
+            'Analytics for network.',
+            true,
+            true,
+            false,
+            '{"type":"object","doc":"Network information.","fields":[{"name":"context","doc":"Class name of the context which started the call to the network.","type":"string"},{"name":"resource","doc":"Name of the resource requested","type":"string"},{"name":"network_state","doc":"upload or download","type":"string"},{"name":"length","doc":"Number of bytes transmitted","type":"number"}]}'
+        ),
+        (
+            @logprobe_service_stream_id,
+            1,
+            'Service',
+            'Analytics for service interaction.',
+            true,
+            true,
+            false,
+            '{"type":"object","doc":"Service interaction.","fields":[{"name":"service","doc":"The class name of the service.","type":"string"},{"name":"status","doc":"Status information about the service. Either ON or OFF.","type":"string"}]}'
+        ),
+        (
+            @logprobe_widget_stream_id,
+            1,
+            'Widget',
+            'Analytics for widget interaction.',
+            true,
+            true,
+            false,
+            '{"type":"object","doc":"Widget interaction.","fields":[{"name":"id","doc":"The id of the view which produced this event.","type":"number"},{"name":"name","doc":"The human readable name of the view which produced this event. Will read the getContentDescription() of the view.","type":"string"},{"name":"extra","doc":"Extra information supplied for this interaction.","optional":true,"type":"string"}]}'
+        ),
+        (
+            @mobility_regular_stream_id,
+            2012050700,
+            'Mobility - Regular',
+            'This records only the user\'s mode.',
+            true,
+            true,
+            NULL,
+            '{"type":"object","doc":"Only requires the user\'s mode.","fields":[{"name":"mode","type":"string","doc":"The user\'s mode."}]}'
+        ),
+        (
+            @mobility_error_stream_id,
+            2012061300,
+            'Mobility - Error',
+            'This is used to signify an error with a point. The mode is the only thing that is required, which must be null.',
+            true,
+            true,
+            NULL,
+            '{"type":"object","doc":"Only requires the user\'s mode, which must be \\"error\\".","fields":[{"name":"mode","type":"string","doc":"The user\'s mode."}]}'
+        ),
+        (
+            @mobility_extended_stream_id,
+            2012050700,
+            'Mobility - Extended',
+            'This records the user\'s mode as well as accelerometer, WiFi, and GPS data.',
+            true,
+            true,
+            NULL,
+            '{"type":"object","doc":"Contains the user\'s mode as well as the sensor data.","fields":[{"name":"mode","type":"string","doc":"The user\'s mode."},{"name":"speed","type":"number","doc":"The user\'s speed in the last minute.","optional":true},{"name":"accel_data","type":"array","constType":{"type":"object","doc":"A single accelerometer reading.","fields":[{"name":"x","type":"number","doc":"The x-component of the accelerometer reading."},{"name":"y","type":"number","doc":"The y-component of the accelerometer reading."},{"name":"z","type":"number","doc":"The z-component of the accelerometer reading."}]},"doc":"An array of the accelerometer readings over the last minute."},{"name":"wifi_data","type":"object","doc":"A WiFi reading from the last minute.","fields":[{"name":"time","type":"number","doc":"The time this data was recorded."},{"name":"timezone","type":"string","doc":"The time zone of the device when this data was recorded."},{"name":"scan","type":"array","constType":{"type":"object","doc":"A single access point\'s information.","fields":[{"name":"ssid","type":"string","doc":"The access point\'s SSID."},{"name":"strength","type":"number","doc":"The strength of the signal from the access point."}]},"doc":"The scan of WiFi information."}]}]}'
+        );
+
+-- Get the database IDs for the streams.
+SET
+    @analytics_prompt_id = 
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @analytics_prompt_stream_id
+        ),
+    @analytics_trigger_id =  
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @analytics_trigger_stream_id
+        ),
+    @logprobe_activity_id =  
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @logprobe_activity_stream_id
+        ),
+    @logprobe_log_id =  
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @logprobe_log_stream_id
+        ),
+    @logprobe_network_id =  
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @logprobe_network_stream_id
+        ),
+    @logprobe_service_stream_id =  
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @logprobe_service_stream_id
+        ),
+    @logprobe_widget_id =  
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @logprobe_widget_stream_id
+        ),
+    @mobility_regular_id =  
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @mobility_regular_stream_id
+        ),
+    @mobility_error_id =  
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @mobility_error_stream_id
+        ),
+    @mobility_extended_id = 
+        (
+            SELECT id 
+            FROM observer_stream 
+            WHERE stream_id = @mobility_extended_stream_id
+        );
+
+-- Connect the observers to their respective streams.
+INSERT INTO
+    observer_stream_link(observer_id, observer_stream_id)
+    VALUES
+        (@analytics_id, @analytics_prompt_id),
+        (@analytics_id, @analytics_trigger_id),
+        (@logprobe_id, @logprobe_activity_id),
+        (@logprobe_id, @logprobe_log_id),
+        (@logprobe_id, @logprobe_network_id),
+        (@logprobe_id, @logprobe_service_stream_id),
+        (@logprobe_id, @logprobe_widget_id),
+        (@mobility_id, @mobility_regular_id),
+        (@mobility_id, @mobility_error_id),
+        (@mobility_id, @mobility_extended_id);

--- a/db/migration/V3__Insert_seeds.sql
+++ b/db/migration/V3__Insert_seeds.sql
@@ -1,0 +1,43 @@
+-- Adds the preferences to the preferences table.
+INSERT INTO preference(p_key, p_value) VALUES 
+    ('document_directory', '${base_dir}/documents'), 
+    ('image_directory', '${base_dir}/images'), 
+    ('max_files_per_dir', '1000'), 
+    ('document_depth', '5'), 
+    ('visualization_server_address', 'http://opencpu.org/R/pub/Mobilize'),
+    ('max_survey_response_page_size', '-1'),
+    ('recaptcha_public_key', ''),
+    ('recaptcha_private_key', ''),
+    ('public_class_id', 'urn:class:public'),
+    ('video_directory', '${base_dir}/videos'),
+    ('audio_directory', '${base_dir}/audio'),
+    ('audit_log_location', '${base_dir}/audits/'),
+    ('fully_qualified_domain_name', '${fqdn}'),
+    ('ssl_enabled', 'false'),
+    ('default_can_create_privilege', 'true'), 
+    ('default_survey_response_sharing_state', 'private'),
+    ('privileged_user_in_class_can_view_others_mobility', 'false'),
+    ('mobility_enabled', 'true'),
+    ('self_registration_allowed', 'true'),
+    ('terms_of_service', 'We will collect as much data as is required by our system and that you offer to our system, no more, no less. We will keep the data as secure as possible, but you recognize that unforeseeable incidents may happen that cause data to be lost or stolen. We make every effort to keep our systems as secure as possible.
+Any website collects information about its users. This typically includes data about the device being used (for example, a web browser or a smartphone application), the IP address of the system making requests, HTTP cookies, request timestamps and timezones, and any data (including images) being provided to interact with the various application functions. In addition to the standard HTTP headers and payloads just described, ohmage also collects location information, system analytics regarding smartphone usage, personal data streams, and your email address, if provided. By using the ohmage smartphone application, you acknowledge that this information is being collected about you and your activities. If you are a software developer, the ohmage server APIs are fully documented on GitHub [1].
+Why We Collect This Data
+ohmage is designed for the analysis of scripted self-report (survey) data, smartphone analytics data, and personal data streams such as user activity data. All of these data streams can be combined together to provide useful information to end users, researchers, clinicians and students from a wide variety of application domains. If you are a participant in a study in a domain of research around health behaviors, you will be given a very thorough explanation about the study and the information collected. This process is handled by the IRB (Institutional Review Board) from various institutions [2]. Each research study has its own IRB application that is thoroughly vetted and approved by an IRB before the study can begin.
+If you are a participant in a research study, you always have the option to opt-out and discontinue your participation.
+Your Privacy
+In cases where you have self-registered with ohmage, it is up to you to choose a username and password. You are also asked to provide your email address. We will only use your email address to contact you to complete the registration process and reset your password should it be necessary. CENS-MobilizeLabs does not share or sell your email address or personal information with any third-party.
+In ohmage, you have control over the privacy settings of your self-report data. Each self-report may be marked as "shared" or "private". When a self-report is marked as private, only you, system administrators, and research supervisors can view that data. A research supervisor is a person who is managing a population of participants in order to perform research. As a participant, you may also delete your self-report responses.
+For passively collected data such as smartphone analytics and personal data streams, the data is private to you, system administrators and research supervisors. This information is used to analyze self-report data along different axes. For example, your activity may be compared to your self-reports about sleep in a sleep study.
+One of our goals is to put you in control of your data. It is also important for system administrators and research supervisors to have access to your data in order to interpret patterns, perform research, and fix system problems. The ohmage team will put your privacy first and we will never share your data with a third-party.
+Final Notes
+We are constantly striving to build a great software and a pleasing experience to our end users. We think our app is awesome and we hope you enjoy using it!
+1. https://github.com/cens/ohmageServer/wiki
+2. The UCLA IRB information can be found here: http://ohrpp.research.ucla.edu/pages/about-irb
+    '),
+    ('mail_registration_activation_function', '#activate'),
+    ('mail_registration_sender_address', 'no-reply@ohmage.org'),
+    ('mail_registration_subject', 'ohmage: New Account Request'),
+    ('mail_registration_text', '<h3>Registration Activation</h3><p>Thank you for creating an account. Getting started instructions can be found at this link: http://demo.ohmage.org/. To activate your account, follow the link at the end of this message. By following the link you agree to our terms of service.</p><_TOS_><br /><_REGISTRATION_LINK_>'),
+    ('mail_password_reset_sender_address', 'no-reply@ohmage.org'),
+    ('mail_password_reset_subject', 'ohmage: Password Reset'),
+    ('mail_password_reset_text', '<h3>Password Reset</h3><p>Your password has been reset. Please attempt to login with your new password below at which time you will be prompted to change your password.</p>');

--- a/db/migration/V4__upgrade_216_217.sql
+++ b/db/migration/V4__upgrade_216_217.sql
@@ -2,7 +2,7 @@ INSERT INTO preference VALUES
     ('file_directory', '${base_dir}/files');
 
 INSERT INTO preference VALUES 
-    ('user_setup_enabled', 'true');
+    ('user_setup_enabled', 'false');
 
 ALTER TABLE url_based_resource 
     ADD COLUMN `metadata` text CHARACTER SET utf8 DEFAULT NULL;

--- a/db/migration/V4__upgrade_216_217.sql
+++ b/db/migration/V4__upgrade_216_217.sql
@@ -1,0 +1,456 @@
+INSERT INTO preference VALUES 
+    ('file_directory', '${base_dir}/files');
+
+INSERT INTO preference VALUES 
+    ('user_setup_enabled', 'true');
+
+ALTER TABLE url_based_resource 
+    ADD COLUMN `metadata` text CHARACTER SET utf8 DEFAULT NULL;
+
+ALTER TABLE class 
+    ADD COLUMN (
+    	`creation_timestamp` datetime DEFAULT null,
+    	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    	);
+
+ALTER TABLE user
+    CHANGE COLUMN `plaintext_password` `initial_password` text CHARACTER SET utf8 DEFAULT NULL;
+    	
+CREATE TRIGGER `class_insert` BEFORE INSERT ON `class`
+	FOR EACH ROW SET new.creation_timestamp = NOW();
+	
+	
+ALTER TABLE user
+    ADD COLUMN `creation_timestamp` datetime DEFAULT null;
+    	
+CREATE TRIGGER `user_insert` BEFORE INSERT ON `user`
+	FOR EACH ROW SET new.creation_timestamp = NOW();
+
+ALTER TABLE campaign 
+    ADD COLUMN (
+       	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    );
+	
+ALTER TABLE user_class 
+    ADD COLUMN (
+    	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    	);
+    	
+ALTER TABLE campaign_class 
+    ADD COLUMN (
+    	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    	);
+
+ALTER TABLE user_role_campaign 
+    ADD COLUMN (
+    	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    	);
+
+ALTER TABLE document_user_role 
+    ADD COLUMN (
+    	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    	);
+    	
+ALTER TABLE document_user_creator 
+    ADD COLUMN (
+    	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    	);
+   
+ALTER TABLE document_campaign_role 
+    ADD COLUMN (
+    	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    	);
+
+ALTER TABLE document_class_role 
+    ADD COLUMN (
+    	`last_modified_timestamp` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    	);
+   	    	
+    	
+
+UPDATE class SET last_modified_timestamp = 0;
+UPDATE campaign SET last_modified_timestamp = 0;    	
+
+UPDATE user_class SET last_modified_timestamp = 0;
+UPDATE campaign_class SET last_modified_timestamp = 0;
+UPDATE user_role_campaign SET last_modified_timestamp = 0;
+UPDATE document_user_role SET last_modified_timestamp = 0;
+UPDATE document_user_creator SET last_modified_timestamp = 0;
+UPDATE document_campaign_role SET last_modified_timestamp = 0;
+UPDATE document_class_role SET last_modified_timestamp = 0;
+
+UPDATE class JOIN 
+  (SELECT t1.urn AS urn,
+         t1.creation_timestamp AS creation_timestamp,
+         IF(t2.urn IS NULL OR t2.update_timestamp < t1.creation_timestamp, 
+           t1.creation_timestamp, 
+       	   t2.update_timestamp) AS update_timestamp
+  FROM
+    (SELECT ap.param_value AS urn, MAX(a.db_timestamp) AS creation_timestamp
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+     WHERE a.uri = '/app/class/create'
+        AND a.response like '%success%'
+        AND ap.param_key = 'class_urn'
+     GROUP BY ap.param_value
+    ) AS t1
+  LEFT JOIN 
+    (SELECT ap.param_value AS urn, max(a.db_timestamp) AS update_timestamp
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+        JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+     WHERE a.uri = '/app/class/update'
+        AND a.response like '%success%'
+        AND ap.param_key = 'class_urn'
+	    AND ( ap2.param_key = 'class_name' OR ap2.param_key = 'description') 
+     GROUP BY ap.param_value
+    ) AS t2 ON (t1.urn = t2.urn)
+  ) AS audit ON (class.urn = audit.urn)
+SET class.creation_timestamp = audit.creation_timestamp,
+    class.last_modified_timestamp = audit.update_timestamp
+WHERE class.creation_timestamp IS NULL;
+
+UPDATE campaign c JOIN 
+  (SELECT ap.param_value AS urn, MAX(a.db_timestamp) AS last_modified_timestamp
+   FROM audit a 
+     JOIN audit_parameter ap ON (a.id = ap.audit_id)
+     JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+   WHERE (a.uri = '/app/campaign/update')
+      AND a.response like '%success%'
+      AND ap.param_key = 'campaign_urn'
+      AND ap2.param_key IN ('xml', 'description', 'privacy_state', 'running_state') 
+   GROUP BY ap.param_value
+  ) AS audit ON c.urn = audit.urn
+SET c.last_modified_timestamp = audit.last_modified_timestamp
+WHERE c.last_modified_timestamp = 0;
+
+
+UPDATE campaign c
+SET c.last_modified_timestamp = c.creation_timestamp 
+WHERE c.creation_timestamp > c.last_modified_timestamp; 
+
+UPDATE user JOIN 
+    (SELECT ap.param_value AS username, MAX(a.db_timestamp) AS last_modified_timestamp
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+     WHERE (a.uri = '/app/user/update' OR a.uri = '/app/user/create')
+        AND a.response like '%success%'
+        AND ap.param_key = 'username'
+     GROUP BY ap.param_value
+    ) AS audit ON user.username = audit.username
+SET user.last_modified_timestamp = audit.last_modified_timestamp
+WHERE user.last_modified_timestamp = 0;
+
+UPDATE user u JOIN user_personal up ON (u.id = up.user_id)
+SET u.last_modified_timestamp = up.last_modified_timestamp
+WHERE u.last_modified_timestamp < up.last_modified_timestamp;
+
+UPDATE user u JOIN
+  (SELECT u.id as uid, c.id as cid, MAX(c.last_modified_timestamp) as ts
+   FROM user u JOIN user_class uc on (u.id = uc.user_id)
+   JOIN class c on (c.id = uc.class_id)
+   GROUP BY u.id
+  ) AS t1 on (u.id = t1.uid)
+SET u.last_modified_timestamp = t1.ts
+WHERE u.last_modified_timestamp = 0;
+
+UPDATE user u 
+SET u.last_modified_timestamp = "2013-01-01 00:00:01"
+WHERE u.last_modified_timestamp = 0;
+  
+UPDATE user JOIN 
+    (SELECT ap.param_value AS username, MAX(a.db_timestamp) AS creation_timestamp
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+     WHERE a.uri = '/app/user/create'
+        AND a.response like '%success%'
+        AND ap.param_key = 'username'
+     GROUP BY ap.param_value
+    ) AS audit ON user.username = audit.username
+SET user.creation_timestamp = audit.creation_timestamp
+WHERE user.creation_timestamp IS NULL;
+
+UPDATE
+  user u
+	JOIN
+    (SELECT u.id AS user_id, 
+        ap.param_value AS first_name, ap2.param_value AS last_name, 
+        ap3.param_value AS organization, ap4.param_value AS personal_id, 
+        MIN(a.db_timestamp) AS creation_timestamp,
+        MAX(a.db_timestamp) AS last_modified_timestamp
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+        JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+        JOIN audit_parameter ap3 ON (a.id = ap3.audit_id)
+        JOIN audit_parameter ap4 ON (a.id = ap4.audit_id) 
+        JOIN user_personal up ON (ap.param_value=up.first_name 
+          AND ap2.param_value=up.last_name 
+          AND ap3.param_value=up.organization 
+          AND ap4.param_value=up.personal_id)
+        JOIN user u ON (u.id = up.user_id)
+        LEFT JOIN (
+          SELECT u.id AS user_id, u.username AS username, 
+            MAX(a.db_timestamp) as del_ts, ap.param_value
+          FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+            JOIN user u on (u.username = ap.param_value)
+          WHERE a.uri = '/app/user/delete'
+            AND a.response LIKE '%success%'
+            AND ap.param_key = 'user_list'
+            AND ap.param_value RLIKE u.username
+          GROUP BY u.id
+        ) AS del on (u.id=del.user_id)
+     WHERE a.uri = '/app/user/setup'
+        AND a.response like '%success%'
+        AND ap.param_key = 'first_name'
+        AND ap2.param_key = 'last_name'
+        AND ap3.param_key = 'organization'
+        AND ap4.param_key = 'personal_id'
+        AND (del.del_ts IS NULL or a.db_timestamp > del.del_ts)
+     GROUP BY u.id
+    ) AS audit ON (u.id = audit.user_id)
+SET u.creation_timestamp = audit.creation_timestamp
+WHERE u.creation_timestamp IS NULL;
+
+UPDATE user 
+SET user.creation_timestamp = user.last_modified_timestamp 
+WHERE user.creation_timestamp IS NULL;
+
+
+UPDATE class c, 
+       (SELECT MIN(db_timestamp) AS ts FROM audit) AS a
+SET c.creation_timestamp = a.ts
+where c.urn = 'urn:class:public';
+
+UPDATE class c
+SET c.last_modified_timestamp = c.creation_timestamp
+where c.urn = 'urn:class:public'
+    AND c.last_modified_timestamp = 0; 
+
+UPDATE user u,
+       (SELECT MIN(db_timestamp) AS ts FROM audit) AS a
+SET u.creation_timestamp = a.ts
+where u.username = 'ohmage.admin';
+
+UPDATE class c 
+  JOIN (SELECT uc.class_id AS id, MIN(u.creation_timestamp) AS user_ts
+        FROM user_class uc JOIN user u ON (uc.user_id = u.id)
+        WHERE u.creation_timestamp > 0
+	    GROUP BY uc.class_id) AS t1 ON (c.id = t1.id)
+  JOIN (SELECT cc.class_id AS id, MIN(ca.creation_timestamp) AS ca_ts
+        FROM campaign_class cc JOIN campaign ca ON (cc.campaign_id = ca.id)
+        GROUP BY cc.class_id) AS t2 ON (c.id = t2.id)
+SET c.creation_timestamp = IF(t1.user_ts < t2.ca_ts, t1.user_ts, t2.ca_ts)
+where c.creation_timestamp IS NULL;
+
+
+
+UPDATE 
+  user_class uc JOIN 
+  	(SELECT uc.user_id AS user_id, uc.class_id AS class_id, uc.user_class_role_id AS user_class_role_id, MAX(t1.ts) AS max_ts,
+  	   u.username AS username
+  	 FROM user_class uc
+  	   JOIN class c ON (uc.class_id = c.id)
+       JOIN user u ON (uc.user_id = u.id)
+       JOIN user_class_role ucr ON (uc.user_class_role_id = ucr.id)
+       JOIN 
+        (SELECT ap.param_value AS urn, ap2.param_value AS user_list, a.db_timestamp AS ts 
+         FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+           JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+         WHERE a.uri = '/app/class/update'
+       	   AND a.response like '%success%'
+       	   AND ap.param_key = 'class_urn'
+       	   AND ap2.param_key = 'user_role_list_add'
+        ) AS t1 ON (c.urn = t1.urn AND t1.user_list RLIKE CONCAT(u.username, ";", ucr.role))
+     GROUP BY uc.user_id, uc.class_id, uc.user_class_role_id
+    ) AS src ON (uc.user_id=src.user_id AND uc.class_id=src.class_id AND uc.user_class_role_id=src.user_class_role_id)
+SET uc.last_modified_timestamp = src.max_ts
+WHERE src.max_ts > uc.last_modified_timestamp;
+
+UPDATE
+  user_class uc JOIN 
+  (SELECT uc.user_id AS user_id, uc.class_id AS class_id, MAX(t1.ts) as max_ts 
+   FROM user_class uc JOIN class c ON (uc.class_id = c.id)
+    JOIN user u ON (uc.user_id = u.id)
+    JOIN 
+    (SELECT ap.param_value AS urn, ae.extra_value AS username, a.db_timestamp AS ts 
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+       JOIN audit_extra ae ON (a.id = ae.audit_id)
+     WHERE a.uri = '/app/class/create'
+       AND a.response like '%success%'
+       AND ap.param_key = 'class_urn'
+       AND ae.extra_key = 'user'
+     ) AS t1 ON (c.urn = t1.urn AND u.username = t1.username)
+   ) AS src on (uc.user_id = src.user_id AND uc.class_id = src.class_id)
+SET uc.last_modified_timestamp = src.max_ts
+where src.max_ts > uc.last_modified_timestamp;
+
+UPDATE 
+user_class uc 
+    JOIN class c ON (uc.class_id = c.id)
+    JOIN user u ON (uc.user_id = u.id)
+    JOIN user_class_role ucr ON (uc.user_class_role_id = ucr.id)
+SET uc.last_modified_timestamp = IF(u.creation_timestamp > c.creation_timestamp, u.creation_timestamp, c.creation_timestamp)
+WHERE uc.last_modified_timestamp = 0;
+
+
+
+UPDATE 
+  campaign_class cc JOIN 
+  (SELECT cc.campaign_id AS campaign_id, cc.class_id AS class_id, MAX(t1.ts) AS max_ts, cc.last_modified_timestamp  
+   FROM campaign_class cc JOIN class c ON (cc.class_id = c.id)
+    JOIN campaign ca ON (cc.campaign_id = ca.id)
+    JOIN 
+    (SELECT ap.param_value AS urn, ap2.param_value AS class_list, a.db_timestamp AS ts
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+       JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+     WHERE a.uri = '/app/campaign/update'
+       AND a.response like '%success%'
+       AND ap.param_key = 'campaign_urn'
+       AND ap2.param_key = 'class_list_add'
+     ) AS t1 ON (ca.urn = t1.urn AND t1.class_list rlike c.urn)
+   GROUP BY cc.campaign_id, cc.class_id
+  ) AS src on (src.campaign_id = cc.campaign_id AND src.class_id = cc.class_id)
+SET cc.last_modified_timestamp = src.max_ts
+WHERE src.max_ts > cc.last_modified_timestamp;
+
+UPDATE 
+  campaign_class cc JOIN 
+  (SELECT cc.campaign_id AS campaign_id, cc.class_id AS class_id, MAX(t1.ts) AS max_ts, cc.last_modified_timestamp    
+   FROM campaign_class cc JOIN class c ON (cc.class_id = c.id)
+    JOIN campaign ca ON (cc.campaign_id = ca.id)
+    JOIN 
+    (SELECT ap.param_value AS urn, ap2.param_value AS class_list, a.db_timestamp AS ts
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+       JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+     WHERE a.uri = '/app/campaign/create'
+       AND a.response like '%success%'
+       AND ap.param_key = 'campaign_urn'
+       AND ap2.param_key = 'class_urn_list'
+     ) AS t1 ON (ca.urn = t1.urn AND t1.class_list rlike c.urn)
+   GROUP BY cc.campaign_id, cc.class_id
+  ) AS src on (src.campaign_id = cc.campaign_id AND src.class_id = cc.class_id)
+SET cc.last_modified_timestamp = src.max_ts
+WHERE src.max_ts > cc.last_modified_timestamp;
+
+UPDATE 
+  campaign_class cc
+    JOIN class c ON (cc.class_id = c.id)
+    JOIN campaign ca ON (cc.campaign_id = ca.id)
+SET cc.last_modified_timestamp = IF(ca.creation_timestamp > c.creation_timestamp, ca.creation_timestamp, c.creation_timestamp)
+WHERE cc.last_modified_timestamp = 0;
+
+UPDATE 
+  user_role_campaign urc JOIN
+  (SELECT urc.user_id as user_id, urc.campaign_id as campaign_id, 
+     MAX(uc.last_modified_timestamp) AS uc_ts,
+     MAX(cc.last_modified_timestamp) AS cc_ts
+   FROM user_role_campaign urc 
+     JOIN campaign_class cc ON (urc.campaign_id = cc.campaign_id)
+     JOIN user_class uc ON (cc.class_id = uc.class_id)
+   GROUP BY urc.user_id, urc.campaign_id
+   ) AS src on (urc.user_id = src.user_id AND urc.campaign_id = src.campaign_id)
+SET urc.last_modified_timestamp = 
+  IF(src.cc_ts > src.uc_ts, src.cc_ts, src.uc_ts)
+where src.cc_ts > urc.last_modified_timestamp
+  OR src.uc_ts > urc.last_modified_timestamp;
+  
+UPDATE 
+  user_role_campaign urc JOIN 
+  (SELECT urc.campaign_id AS campaign_id, urc.user_id AS user_id, urc.user_role_id AS user_role_id, 
+     MAX(t1.ts) AS max_ts, urc.last_modified_timestamp  
+   FROM user_role_campaign urc 
+    JOIN campaign ca ON (urc.campaign_id = ca.id)
+    JOIN user u ON (urc.user_id = u.id)
+    JOIN user_role ur ON (urc.user_role_id = ur.id)
+    JOIN 
+    (SELECT ap.param_value AS urn, ap2.param_value AS user_list, MAX(a.db_timestamp) AS ts
+     FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+       JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+     WHERE a.uri = '/app/campaign/update'
+       AND a.response like '%success%'
+       AND ap.param_key = 'campaign_urn'
+       AND ap2.param_key = 'user_role_list_add'
+     GROUP BY ap.param_value, ap2.param_value
+     ) AS t1 ON (ca.urn = t1.urn AND t1.user_list rlike CONCAT(u.username,";",ur.role))
+   GROUP BY u.id, ca.id, ur.id
+  ) AS src on (src.campaign_id = urc.campaign_id AND src.user_id = urc.user_id AND src.user_role_id=urc.user_role_id)
+SET urc.last_modified_timestamp = src.max_ts
+WHERE src.max_ts > urc.last_modified_timestamp;
+
+UPDATE
+  user_role_campaign urc 
+  JOIN campaign c ON (urc.campaign_id = c.id)
+  JOIN user u ON (urc.user_id = u.id)
+SET urc.last_modified_timestamp = IF(u.creation_timestamp > c.creation_timestamp, u.creation_timestamp, c.creation_timestamp)
+WHERE urc.last_modified_timestamp = 0;
+
+
+ 
+UPDATE
+  document_user_role dur 
+  JOIN document d ON (dur.document_id = d.id)
+SET dur.last_modified_timestamp = d.creation_timestamp
+WHERE dur.last_modified_timestamp = 0;
+
+ -- document_user_creator: update using document's creation_timestamp
+ -- Those that were not set referenced to deleted document
+UPDATE
+  document_user_creator duc 
+  JOIN document d ON (duc.document_id = d.id)
+SET duc.last_modified_timestamp = d.creation_timestamp
+WHERE duc.last_modified_timestamp = 0;
+
+UPDATE
+  document_class_role dcr JOIN
+  (SELECT dcr.document_id as document_id, dcr.class_id as class_id, 
+     dcr.document_role_id as document_role_id, MAX(t1.ts) as max_ts
+   FROM  document_class_role dcr
+     JOIN document_role dr ON (dcr.document_role_id = dr.id)
+     JOIN document d ON (dcr.document_id = d.id)
+     JOIN class c ON (dcr.class_id = c.id)
+     JOIN 
+     (SELECT ap.param_value as uuid, ap2.param_value as class_list, a.db_timestamp as ts
+      FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+        JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+      WHERE a.uri = '/app/document/update'
+        AND a.response like '%success%'
+        AND ap.param_key = 'document_id'
+        AND ap2.param_key = 'class_role_list_add'
+     ) AS t1 on (t1.uuid = d.uuid AND t1.class_list like CONCAT(c.urn, ";", dr.role))
+   GROUP BY dcr.document_id, dcr.class_id, dcr.document_role_id
+  ) AS src on (src.document_id = dcr.document_id 
+  	AND src.class_id=dcr.class_id 
+  	AND src.document_role_id = dcr.document_role_id)
+SET dcr.last_modified_timestamp = src.max_ts
+WHERE src.max_ts > dcr.last_modified_timestamp;
+
+UPDATE
+  document_class_role dcr 
+  JOIN document d ON (dcr.document_id = d.id)
+SET dcr.last_modified_timestamp = d.creation_timestamp
+WHERE dcr.last_modified_timestamp = 0;
+
+UPDATE
+  document_campaign_role dcr JOIN
+  (SELECT dcr.document_id as document_id, dcr.campaign_id as campaign_id, 
+     dcr.document_role_id as document_role_id, MAX(t1.ts) as max_ts
+   FROM  document_campaign_role dcr
+     JOIN document_role dr ON (dcr.document_role_id = dr.id)
+     JOIN document d ON (dcr.document_id = d.id)
+     JOIN campaign c ON (dcr.campaign_id = c.id)
+     JOIN 
+     (SELECT ap.param_value as uuid, ap2.param_value as campaign_list, a.db_timestamp as ts
+      FROM audit a JOIN audit_parameter ap ON (a.id = ap.audit_id)
+        JOIN audit_parameter ap2 ON (a.id = ap2.audit_id)
+      WHERE a.uri = '/app/document/update'
+        AND a.response like '%success%'
+        AND ap.param_key = 'document_id'
+        AND ap2.param_key = 'campaign_role_list_add'
+     ) AS t1 on (t1.uuid = d.uuid AND t1.campaign_list like CONCAT(c.urn, ";", dr.role))
+   GROUP BY dcr.document_id, dcr.campaign_id, dcr.document_role_id
+  ) AS src on (src.document_id = dcr.document_id 
+  	AND src.campaign_id=dcr.campaign_id 
+  	AND src.document_role_id = dcr.document_role_id)
+SET dcr.last_modified_timestamp = src.max_ts
+WHERE src.max_ts > dcr.last_modified_timestamp;
+
+UPDATE
+  document_campaign_role dcr 
+  JOIN document d ON (dcr.document_id = d.id)
+SET dcr.last_modified_timestamp = d.creation_timestamp
+WHERE dcr.last_modified_timestamp = 0;

--- a/db/sql/README.md
+++ b/db/sql/README.md
@@ -1,0 +1,9 @@
+# ** *DEPRECATED in 2.17* **  Manual db prep SQL scripts
+These scripts will prep an ohmage db by piping the list of files below to a database. As this method is now deprecated, please see the README in the `db/` directory or the `db/migration` directory for alternative options
+
+```bash
+sql/base/ohmage-ddl.sql
+sql/preferences/default_preferences.sql
+sql/settings/*.sql
+```
+If you're upgrading from an older ohmage release, you can use the update scripts found in `update/`, noting that multiple version skips will require you to execute each file in order (eg. ohmage 2.14 to ohmage 2.17 requires the execution of `2.14-2.15.sql`, `2.15-2.16.sql` and `2.16-2.17.sql`.

--- a/db/sql/update/2.16-2.17.sql
+++ b/db/sql/update/2.16-2.17.sql
@@ -10,7 +10,7 @@ INSERT INTO preference VALUES
     
 -- Configure user/setup functionality. If the row already exist, update it.
 INSERT INTO preference VALUES 
-    ('user_setup_enabled', 'true')
+    ('user_setup_enabled', 'false')
     ON DUPLICATE KEY UPDATE p_value = VALUES(p_value) ;
  
 -- Add a metadata column to the url_based_resource table to keep track of 


### PR DESCRIPTION
PR does a couple things:
- Add first-class db migration path via flyway
- "deprecates" the manual sql script method starting with 2.17 release
- A bunch of readmes to explain the options and flyway setup necessary to accomplish migrations.
